### PR TITLE
Fix onion URLs

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -76,7 +76,7 @@ PROJECTS = [
 		"name": "mkonion",
 		"language": "Go",
 		"url": "/src/mkonion",
-		"description": "Small, simple and self-contained tool to create a Tor onion address for an existing container without restarts or modification of the container. I use this to manage the [onion link for this website](http://dqzsjhefvopcfbn5.onion/)."
+		"description": "Small, simple and self-contained tool to create a Tor onion address for an existing container without restarts or modification of the container. I use this to manage the [onion link for this website](http://jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion/)."
 	},
 	{
 		"name": "redone",

--- a/srv/overlay/_host/etc/nginx/conf.d/cyphar.conf
+++ b/srv/overlay/_host/etc/nginx/conf.d/cyphar.conf
@@ -122,10 +122,8 @@ server {
 		# TODO: Add Feature-Policy. Annoyingly it can't be switched to
 		#       deny-by-default.
 
-		# Add our .onion address URLs.
-		set $my_tor2 "mfzzxl26gc7y46mz.onion:80";
-		set $my_tor3 "jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion:80";
-		add_header Alt-Svc 'h2="$my_tor3", http/1.1="$my_tor3", h2="$my_tor2", http/1.1="$my_tor2"; persist=1' always;
+		# Add our .onion address URL
+		add_header Onion-Location 'jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion$request_uri' always;
 	}
 
 	# We redirect to cyphar.com for .well-known.

--- a/templates/home.html
+++ b/templates/home.html
@@ -32,12 +32,9 @@ and coauthored <a href="{{ url_for("papers") }}">several papers</a> based on res
 I've done at the University of Sydney.</p>
 
 <p>While this site doesn't use Cloudflare, it is still available at the
-following onion addresses. If you are a Tor user, please consider using them to
+following onion address. If you are a Tor user, please consider using it to
 increase your privacy.</p>
-<ul class="dots">
-	<li><a href="http://jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion/"><code>jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion</code></a> (v3)</li>
-	<li><a href="http://mfzzxl26gc7y46mz.onion/"><code>mfzzxl26gc7y46mz.onion</code></a> (v2)</li>
-</ul>
+<p><a href="http://jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion/"><code>jfxets67sl7jq7euqo5hypuu2tfahfw25kejz53pjdbwyq2t4oseswqd.onion</code></a></p>
 
 <h3>Who are you?</h3>
 


### PR DESCRIPTION
- Alt-Svc does not work without a matching TLS certificate for the hidden service; the protocol needs to be identical (HTTPS, HTTP/2). A valid .onion certificate from a CA costs an arm and a leg. Replace Alt-Svc with the "Onion-Location" header, which the Tor Browser supports.
- All v2 addresses are currently unreachable, on recent versions of Tor. Remove them.